### PR TITLE
Fix minor exporter issues and clean up code

### DIFF
--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -21,7 +21,7 @@ without significant importing (it's the same as Godot's tscn format).
 
 import logging
 import bpy
-from bpy.props import StringProperty, BoolProperty, FloatProperty, EnumProperty
+from bpy.props import StringProperty, BoolProperty, EnumProperty
 from bpy_extras.io_utils import ExportHelper
 from .structures import ValidationError
 from . import export_godot

--- a/io_scene_godot/converters/armature.py
+++ b/io_scene_godot/converters/armature.py
@@ -89,7 +89,6 @@ def ordered_bones(bones):
     ordered = []
 
     def visit(bone):
-        nonlocal ordered
         ordered.append(bone)
 
         for child in bone.children:

--- a/io_scene_godot/converters/multimesh.py
+++ b/io_scene_godot/converters/multimesh.py
@@ -13,7 +13,7 @@ def export_multimesh_node(escn_file, export_settings,
     """Export blender particle to a MultiMeshInstance"""
     context = bpy.context
     dg_eval = context.evaluated_depsgraph_get()
-    obj_eval = context.object.evaluated_get(dg_eval)
+    obj_eval = obj.evaluated_get(dg_eval)
 
     multimeshid_active = None
     for _ps in obj_eval.particle_systems:
@@ -59,7 +59,7 @@ def has_particle(node):
     """Returns True if the object has particles"""
     context = bpy.context
     dg_eval = context.evaluated_depsgraph_get()
-    obj_eval = context.object.evaluated_get(dg_eval)
+    obj_eval = node.evaluated_get(dg_eval)
 
     return len(obj_eval.particle_systems) > 0
 
@@ -132,7 +132,6 @@ class MultiMeshConverter:
         """Evaluates object & converts to final multimesh, ready for export.
         The multimesh is only temporary."""
         transform_array = []
-        float32array = ''
         for _particle in self.particle_system.particles:
             quat_x = mathutils.Quaternion((1.0, 0.0, 0.0), math.radians(90.0))
             quat_y = mathutils.Quaternion((0.0, 1.0, 0.0), math.radians(90.0))

--- a/io_scene_godot/converters/physics.py
+++ b/io_scene_godot/converters/physics.py
@@ -72,7 +72,6 @@ def export_collision_shape(escn_file, export_settings, node, parent_gd_node,
     shape_id = None
     col_shape = None
     if rbd.collision_shape in ("CONVEX_HULL", "MESH"):
-        is_convex = rbd.collision_shape == "CONVEX_HULL"
         if rbd.collision_shape == "CONVEX_HULL":
             shape_id = generate_convex_shape(
                 escn_file, export_settings, node


### PR DESCRIPTION
## Summary
- remove unused import and variables
- evaluate particle systems on provided objects instead of global context
- drop unnecessary `nonlocal` usage in armature helper

## Testing
- `pylint io_scene_godot`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae89e882708332b2b89b3c322b6159